### PR TITLE
Added the ability to get / put / delete hexadecimal keys and values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+all:
+	go build cmd/leveldbctl/leveldbctl.go
 test:
 	go test -v -covermode=count -coverprofile=coverage.out ./...
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ LevelDB control command.
 
 This command provides easy way to CRUD operation on LevelDB.
 
-```
+```sh
 $ leveldbctl put foo bar
 put foo: bar into ./.
 $ leveldbctl get foo
@@ -25,15 +25,14 @@ bar
 
 ## Install
 
-```
+```sh
 $ export GO111MODULE=on
 $ go get github.com/yuuichi-fujioka/go-leveldbctl/cmd/leveldbctl
 ```
 
 ## Usage
 
-```
-$ leveldbctl -h
+```sh
 NAME:
    leveldbctl - A new cli application
 
@@ -54,7 +53,20 @@ COMMANDS:
 
 GLOBAL OPTIONS:
    --dbdir value, -d value  LevelDB Directory (default: "./") [$LEVELDB_DIR]
+   --hexkey, --xk           get / put hexadecimal keys
+   --hexvalue, --xv         get / put hexadecimal values
    --help, -h               show help
    --version, -v            print the version
+```
+
+For hexadecimal keys and values:
+
+```sh
+$ export LEVELDB_DIR=${HOME}/.bitcoin/index
+$ leveldbctl -xk g 62f2a1f90489f1f74e441f325ec6f532df8286847d7c7a14000000000000000000|xxd -p
+89fe04a3db1d801d92188d350880fec55300008020edd4d15faba7c63dd7
+c83961bf6783a691fb8f5f6887120000000000000000009f413c1df7e296
+4af9babb54e46d4414eaad550b27b409e29ab80a832ac64ce9966ab95ddf
+8e1417baf3db320a
 ```
 

--- a/cmd/leveldbctl/leveldbctl.go
+++ b/cmd/leveldbctl/leveldbctl.go
@@ -10,15 +10,15 @@ import (
 	"github.com/yuuichi-fujioka/go-leveldbctl/pkg/leveldbctl"
 )
 
-func kvfmt(ishex bool, kvarg string) []byte {
+func kvfmt(ishex bool, kvarg string) ([]byte, string) {
 	if !ishex {
-		return []byte(kvarg)
+		return []byte(kvarg), "%s"
 	}
 	kv, err := hex.DecodeString(kvarg)
 	if err != nil {
 		log.Fatal(err)
 	}
-	return kv
+	return kv, "%x"
 }
 
 func main() {
@@ -93,13 +93,14 @@ func main() {
 					}
 					return cli.ShowSubcommandHelp(c)
 				}
-				key := kvfmt(c.GlobalBool("xk"), c.Args()[0])
-				value := kvfmt(c.GlobalBool("xv"), c.Args()[1])
+				key, kfmt := kvfmt(c.GlobalBool("xk"), c.Args()[0])
+				value, vfmt := kvfmt(c.GlobalBool("xv"), c.Args()[1])
 				err := leveldbctl.Put(c.GlobalString("dbdir"), key, value)
 				if err != nil {
 					return err
 				}
-				fmt.Printf("put %s: %s into %s.\n", key, value, c.GlobalString("dbdir"))
+				fmtstr := fmt.Sprintf("put %s: %s into %s.\n", kfmt, vfmt, "%s")
+				fmt.Printf(fmtstr, key, value, c.GlobalString("dbdir"))
 				return nil
 			},
 		},
@@ -118,7 +119,7 @@ func main() {
 					}
 					return cli.ShowSubcommandHelp(c)
 				}
-				key := kvfmt(c.GlobalBool("xk"), c.Args()[0])
+				key, _ := kvfmt(c.GlobalBool("xk"), c.Args()[0])
 				value, ok, err := leveldbctl.Get(c.GlobalString("dbdir"), key)
 				if err != nil {
 					return err
@@ -146,12 +147,13 @@ func main() {
 					}
 					return cli.ShowSubcommandHelp(c)
 				}
-				key := kvfmt(c.GlobalBool("xk"), c.Args()[0])
+				key, kfmt := kvfmt(c.GlobalBool("xk"), c.Args()[0])
 				err := leveldbctl.Delete(c.GlobalString("dbdir"), key)
 				if err != nil {
 					return err
 				}
-				fmt.Printf("%s is deleted\n", key)
+				fmtstr := fmt.Sprintf("%s is deleted\n", kfmt)
+				fmt.Printf(fmtstr, key)
 				return nil
 			},
 		},

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/yuuichi-fujioka/go-leveldbctl
 
+go 1.14
+
 require (
 	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db // indirect
 	github.com/onsi/ginkgo v1.7.0 // indirect

--- a/pkg/leveldbctl/db.go
+++ b/pkg/leveldbctl/db.go
@@ -27,7 +27,7 @@ func Init(dbpath string) error {
 	return nil
 }
 
-func Put(dbpath, key, value string) error {
+func Put(dbpath string, key []byte, value []byte) error {
 	if !dbexists(dbpath) {
 		return fmt.Errorf("%s is not leveldb", dbpath)
 	}
@@ -38,11 +38,11 @@ func Put(dbpath, key, value string) error {
 	}
 	defer db.Close()
 
-	err = db.Put([]byte(key), []byte(value), nil)
+	err = db.Put(key, value, nil)
 	return err
 }
 
-func Get(dbpath, key string) (string, bool, error) {
+func Get(dbpath string, key []byte) (string, bool, error) {
 	if !dbexists(dbpath) {
 		return "", false, fmt.Errorf("%s is not leveldb", dbpath)
 	}
@@ -53,7 +53,7 @@ func Get(dbpath, key string) (string, bool, error) {
 	}
 	defer db.Close()
 
-	has, err := db.Has([]byte(key), nil)
+	has, err := db.Has(key, nil)
 	if err != nil {
 		return "", false, fmt.Errorf("cannot open leveldb")
 	}
@@ -61,14 +61,14 @@ func Get(dbpath, key string) (string, bool, error) {
 		return "", false, nil
 	}
 
-	value, err := db.Get([]byte(key), nil)
+	value, err := db.Get(key, nil)
 	if err != nil {
 		return "", true, fmt.Errorf("cannot get value")
 	}
 	return string(value), true, nil
 }
 
-func Delete(dbpath, key string) error {
+func Delete(dbpath string, key []byte) error {
 	if !dbexists(dbpath) {
 		return fmt.Errorf("%s is not leveldb", dbpath)
 	}
@@ -79,7 +79,7 @@ func Delete(dbpath, key string) error {
 	}
 	defer db.Close()
 
-	err = db.Delete([]byte(key), nil)
+	err = db.Delete(key, nil)
 	return err
 }
 

--- a/pkg/leveldbctl/db_test.go
+++ b/pkg/leveldbctl/db_test.go
@@ -1,6 +1,7 @@
 package leveldbctl
 
 import (
+	"bytes"
 	"io/ioutil"
 	"os"
 	"path"
@@ -45,9 +46,9 @@ func TestCRUD(t *testing.T) {
 	}
 
 	// const
-	v := "Foo"
-	k := "asdf"
-	k2 := "asdf2"
+	v := []byte("Foo")
+	k := []byte("asdf")
+	k2 := []byte("asdf2")
 
 	// get from blank db
 	value, ok, err := Get(dbdir, k)
@@ -75,7 +76,7 @@ func TestCRUD(t *testing.T) {
 	if !ok {
 		t.Errorf("Key{%s} must be exist.", k)
 	}
-	if value != v {
+	if !bytes.Equal(v, []byte(value)) {
 		t.Errorf("value should be %s but that is %s.", v, value)
 	}
 
@@ -134,7 +135,7 @@ func TestWalk(t *testing.T) {
 
 	// set value
 	for k, v := range keyvalue {
-		err := Put(dbdir, k, v)
+		err := Put(dbdir, []byte(k), []byte(v))
 		if err != nil {
 			t.Error(err)
 		}
@@ -165,17 +166,17 @@ func TestCheckingExistenceDB(t *testing.T) {
 	dbdir := path.Join(tmpdir, "existence")
 
 	// Uninitialized Get, Delete, Put, Walk
-	err = Put(dbdir, "k", "v")
+	err = Put(dbdir, []byte("k"), []byte("v"))
 	if err == nil {
 		t.Error("Put not check whether db is initialized")
 	}
 
-	err = Delete(dbdir, "k")
+	err = Delete(dbdir, []byte("k"))
 	if err == nil {
 		t.Error("Delete not check whether db is initialized")
 	}
 
-	value, ok, err := Get(dbdir, "k")
+	value, ok, err := Get(dbdir, []byte("k"))
 	if err == nil {
 		t.Error("Get not check whether db is initialized")
 	}


### PR DESCRIPTION
Your tool is very useful, but I felt it was missing hexadecimal support, in particular to analyse and walk through Bitcoin LevelDB database.
That's mostly what this patch does, I tried to keep the original code as intact as possible, I adapted the tests accordingly.
I've added an `all` target in the `Makefile` to build `leveldbctl` only for convenience, and updated the `README.md` file to reflect the changes.